### PR TITLE
move unneeded to_string, which according to profiler takes ~7% of the time

### DIFF
--- a/rgsync/redis_gears_write_behind.py
+++ b/rgsync/redis_gears_write_behind.py
@@ -389,7 +389,7 @@ class RGWriteBehind(RGWriteBase):
         filter(ShouldProcessHash).\
         foreach(DeleteHashIfNeeded).\
         foreach(CreateAddToStreamFunction(self)).\
-        register(mode='sync', prefix='%s:*' % keysPrefix, eventTypes=eventTypes)
+        register(mode='sync', prefix='%s:*' % keysPrefix, eventTypes=eventTypes, convertToStr=False)
 
         ## create the execution to write each key from stream to DB
         descJson = {
@@ -406,7 +406,8 @@ class RGWriteBehind(RGWriteBase):
                  batch=batch,
                  duration=duration,
                  onFailedPolicy="retry",
-                 onFailedRetryInterval=onFailedRetryInterval)
+                 onFailedRetryInterval=onFailedRetryInterval,
+                 convertToStr=False)
 
 class RGWriteThrough(RGWriteBase):
     def __init__(self, GB, keysPrefix, mappings, connector, name, version=None):
@@ -424,4 +425,4 @@ class RGWriteThrough(RGWriteBase):
         filter(WriteNoReplicate).\
         filter(TryWriteToTarget(self)).\
         foreach(UpdateHash).\
-        register(mode='sync', prefix='%s*' % keysPrefix, eventTypes=['hset', 'hmset'])
+        register(mode='sync', prefix='%s*' % keysPrefix, eventTypes=['hset', 'hmset'], convertToStr=False)


### PR DESCRIPTION
Profiler output:
```
       23042579 function calls (23028082 primitive calls) in 15.306 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   3123/2    2.364    0.001    0.002    0.001 {method 'recv_into' of '_socket.socket' objects}
   300001    2.039    0.000    2.039    0.000 {built-in method redisgears.executeCommand}
   300001    1.823    0.000    5.268    0.000 /var/opt/redislabs/modules/rg/.venv-/lib/python3.7/site-packages/rgsync/redis_gears_write_behind.py:159(func)
   302334    1.112    0.000    1.112    0.000 <string>:173(<lambda>)
   300001    0.787    0.000    0.970    0.000 /var/opt/redislabs/modules/rg/.venv-/lib/python3.7/site-packages/rgsync/redis_gears_write_behind.py:20(ValidateHash)
     2333    0.502    0.000    3.828    0.002 /var/opt/redislabs/modules/rg/.venv-/lib/python3.7/site-packages/pymysql/cursors.py:185(_do_execute_many)
   233301    0.477    0.000    0.689    0.000 /var/opt/redislabs/modules/rg/.venv-/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py:905(construct_params)
   933204    0.448    0.000    1.233    0.000 /var/opt/redislabs/modules/rg/.venv-/lib/python3.7/site-packages/pymysql/connections.py:498(escape)
  1744972    0.390    0.000    0.470    0.000 <string>:289(profileStop)
   933204    0.354    0.000    0.729    0.000 /var/opt/redislabs/modules/rg/.venv-/lib/python3.7/site-packages/pymysql/connections.py:519(escape_string)
   300001    0.325    0.000    0.410    0.000 /var/opt/redislabs/modules/rg/.venv-/lib/python3.7/site-packages/rgsync/common.py:24(GetStreamName)
   233301    0.242    0.000    1.694    0.000 /var/opt/redislabs/modules/rg/.venv-/lib/python3.7/site-packages/pymysql/cursors.py:109(<dictcomp>)
   300001    0.242    0.000    0.242    0.000 {built-in method builtins.sum}
   233301    0.220    0.000    1.987    0.000 /var/opt/redislabs/modules/rg/.venv-/lib/python3.7/site-packages/pymysql/cursors.py:105(_escape_args)
   933204    0.219    0.000    1.451    0.000 /var/opt/redislabs/modules/rg/.venv-/lib/python3.7/site-packages/pymysql/connections.py:512(literal)
```

The to_string entry:
`302334    1.112    0.000    1.112    0.000 <string>:173(<lambda>)`
