### PR TITLE
Pinning rltest to the last release prior to redis-py 4 as a requirement

### DIFF
--- a/sbin/system-setup.py
+++ b/sbin/system-setup.py
@@ -40,8 +40,7 @@ class RGSyncSetup(paella.Setup):
         self.install_gnu_utils()
 
     def common_last(self):
-        self.pip_install("--no-cache-dir git+https://github.com/Grokzen/redis-py-cluster.git@master")
-        self.pip_install("--no-cache-dir git+https://github.com/RedisLabsModules/RLTest.git@master")
+        self.pip_install("rltest==0.4.2")
         self.pip_install("git+https://github.com/RedisGears/gears-cli.git")
 
 #----------------------------------------------------------------------------------------------


### PR DESCRIPTION
This allows a longer-tail migration to the latest version as each repository is ready, without breaking individual projects.
